### PR TITLE
Register Mongolian (Cyrillic) in HARDCODED_TAG_TABLE

### DIFF
--- a/src/speller_repository.rs
+++ b/src/speller_repository.rs
@@ -15,6 +15,16 @@ lazy_static! {
             }
             map.insert(tag.to_string(), tags);
         }
+        // Mongolian (Khalkha, Cyrillic). mn-Mong-* is deferred.
+        map.insert(
+            "mn".to_string(),
+            vec![
+                "mn".to_string(),
+                "mn-MN".to_string(),
+                "mn-Cyrl".to_string(),
+                "mn-Cyrl-MN".to_string(),
+            ],
+        );
         map
     };
 }
@@ -116,5 +126,35 @@ impl SpellerRepository {
         }
 
         None
+    }
+}
+
+#[test]
+fn mongolian_tag_expansion() {
+    let tags = HARDCODED_TAG_TABLE
+        .get("mn")
+        .expect("mn not in HARDCODED_TAG_TABLE");
+    for expected in &["mn", "mn-MN", "mn-Cyrl", "mn-Cyrl-MN"] {
+        assert!(
+            tags.iter().any(|t| t == expected),
+            "expected {:?} in mn tag expansion, got {:?}",
+            expected,
+            tags
+        );
+    }
+}
+
+#[test]
+fn sami_baseline_preserved() {
+    for neutral in &["se", "sma", "smn", "sms", "smj"] {
+        let tags = HARDCODED_TAG_TABLE
+            .get(*neutral)
+            .unwrap_or_else(|| panic!("{} missing from HARDCODED_TAG_TABLE", neutral));
+        assert!(
+            tags.iter().any(|t| t == &format!("{}-Latn-NO", neutral)),
+            "expected {}-Latn-NO in {} expansion",
+            neutral,
+            neutral
+        );
     }
 }


### PR DESCRIPTION
## What

Adds one entry to `HARDCODED_TAG_TABLE` in `src/speller_repository.rs`:

```rust
("mn", vec!["mn", "mn-MN", "mn-Cyrl", "mn-Cyrl-MN"])
```

So that a `mn.bhfst` speller bundle dropped into `Spellers/` registers against every BCP-47 variant that Windows / Office produces in practice.

## Why each tag

- **`mn`** — ISO 639-1 macrolanguage code. The tag Microsoft Word's language picker emits.
- **`mn-MN`** — language + region. Produced by `ResolveLocaleName` for the Mongolia locale.
- **`mn-Cyrl`** — language + script. Disambiguates from traditional Mongolian script (`mn-Mong`), which is *not* covered by a Cyrillic-only speller.
- **`mn-Cyrl-MN`** — fully-qualified variant. Produced by some Office configurations.

## What's deliberately excluded

- **Traditional script** (`mn-Mong-MN`, `mn-Mong-CN`) — has distinct MVS/FVS variation-selector requirements that a Cyrillic-only speller shouldn't claim coverage over.
- **`khk` / `khk-Cyrl-MN`** — Khalkha is what most current source data targets, but Windows / Office never emit the `khk` tag in practice, so adding it would match no real user input.

## Tests

Two unit tests in the same style as `EnumSpellingError.rs::tokens`:

- `mongolian_tag_expansion` — asserts all four BCP-47 variants land in the table under the `"mn"` key.
- `sami_baseline_preserved` — asserts the existing `se / sma / smn / sms / smj` entries still expand to `{neutral}-Latn-NO` (and siblings), guarding against regression in the loop above the insertion.

Both pass against current `master`.

## Context

This PR is the upstream-candidate slice from a downstream fork (`abadrangui/monspell-win`) building a Mongolian Cyrillic spellchecker for Windows / Office. The fork's rebase discipline treats tag-table entries as upstream-candidate, hence this small standalone PR rather than carrying the divergence forever.

Happy to revise if you'd prefer `khk` included anyway, or if a different test-naming convention fits the project better.
